### PR TITLE
Misc. features

### DIFF
--- a/tncontract/__init__.py
+++ b/tncontract/__init__.py
@@ -6,11 +6,11 @@ A simple tensor-network library.
 
 Available subpackages
 ---------------------
-onedimensional
+onedim
     Special purpose classes, methods and function for one dimensional
     tensor networs
 
-twodimensional
+twodim
     Special purpose classes, methods and function for two dimensional
     tensor networs
 """

--- a/tncontract/__init__.py
+++ b/tncontract/__init__.py
@@ -17,5 +17,6 @@ twodimensional
 
 from tncontract.version import __version__
 from tncontract.tensor import *
+from tncontract.label import *
 import tncontract.onedim
 import tncontract.twodim

--- a/tncontract/__init__.py
+++ b/tncontract/__init__.py
@@ -18,5 +18,6 @@ twodimensional
 from tncontract.version import __version__
 from tncontract.tensor import *
 from tncontract.label import *
+import tncontract.matrices
 import tncontract.onedim
 import tncontract.twodim

--- a/tncontract/label.py
+++ b/tncontract/label.py
@@ -1,0 +1,83 @@
+"""
+label
+==========
+
+Module for string-like labels
+"""
+
+__all__ = ['prime_label', 'unprime_label', 'prime_level', 'unique_label']
+
+
+import uuid
+
+
+class Label(str):
+    """Wrapper class for priming string-like labels"""
+
+    def __new__(cls, value, **kwargs):
+        return str.__new__(cls, value)
+
+    def __init__(self, label, parent=None):
+        self._parent = parent
+
+    @property
+    def parent(self):
+        """Return parent label"""
+        return self._parent
+
+    @property
+    def origin(self):
+        """Return origin label"""
+        origin = self
+        while hasattr(origin, "parent"):
+            origin = origin.parent
+        return origin
+
+    @property
+    def parents(self):
+        """Return number of parents for label"""
+        tmp = self
+        level = 0
+        while hasattr(tmp, "parent"):
+            if tmp.parent is not None:
+                tmp = tmp.parent
+                level += 1
+            else:
+                break
+        return level
+
+def prime_label(label, prime="'"):
+    """Put a prime on a label object"""
+    return Label(label+prime, parent=label)
+
+def unprime_label(label, prime="'"):
+    """Remove one prime from label object"""
+    try:
+        parent = label.parent
+    except AttributeError:
+        raise ValueError("label is not primed")
+    if parent+prime == label:
+        return parent
+    else:
+        raise ValueError("label is not primed with \"" + prime + "\"")
+
+def noprime_label(label):
+    """Remove all primes from a label object"""
+    try:
+        return label.origin
+    except AttributeError:
+        return label
+
+def prime_level(label):
+    """Return number of primes on label object"""
+    try:
+        return label.parents
+    except AttributeError:
+        return 0
+
+
+def unique_label():
+    """Generate a long, random string that is very likely to be unique."""
+    return str(uuid.uuid4())
+
+

--- a/tncontract/label.py
+++ b/tncontract/label.py
@@ -5,7 +5,8 @@ label
 Module for string-like labels
 """
 
-__all__ = ['prime_label', 'unprime_label', 'prime_level', 'unique_label']
+__all__ = ['prime_label', 'unprime_label', 'noprime_label', 'prime_level',
+        'unique_label']
 
 
 import uuid

--- a/tncontract/label.py
+++ b/tncontract/label.py
@@ -12,13 +12,17 @@ import uuid
 
 
 class Label(str):
-    """Wrapper class for priming string-like labels"""
+    """Wrapper class for priming labels"""
 
     def __new__(cls, value, **kwargs):
         return str.__new__(cls, value)
 
     def __init__(self, label, parent=None):
         self._parent = parent
+        if isinstance(label, Label):
+            # if input is a Label object copy its properties
+            if parent is None:
+                self._parent = label._parent
 
     @property
     def parent(self):
@@ -48,7 +52,7 @@ class Label(str):
 
 def prime_label(label, prime="'"):
     """Put a prime on a label object"""
-    return Label(label+prime, parent=label)
+    return Label(str(label)+prime, parent=label)
 
 def unprime_label(label, prime="'"):
     """Remove one prime from label object"""
@@ -56,7 +60,7 @@ def unprime_label(label, prime="'"):
         parent = label.parent
     except AttributeError:
         raise ValueError("label is not primed")
-    if parent+prime == label:
+    if str(parent)+prime == label:
         return parent
     else:
         raise ValueError("label is not primed with \"" + prime + "\"")
@@ -75,9 +79,6 @@ def prime_level(label):
     except AttributeError:
         return 0
 
-
 def unique_label():
     """Generate a long, random string that is very likely to be unique."""
     return str(uuid.uuid4())
-
-

--- a/tncontract/matrices.py
+++ b/tncontract/matrices.py
@@ -1,0 +1,64 @@
+"""
+matrices
+==========
+
+Often used matrices
+"""
+
+import numpy as np
+
+#
+# Pauli spin 1/2 operators:
+#
+def sigmap():
+    return np.matrix([[0., 1.], [0., 0.]])
+
+
+def sigmam():
+    return np.matrix([[0., 0.], [1., 0.]])
+
+
+def sigmax():
+    return sigmam()+sigmap()
+
+
+def sigmay():
+    return -1j*sigmap()+1j*sigmam()
+
+
+def sigmaz():
+    return np.matrix([[1., 0.], [0., -1.]])
+
+def destroy(dim):
+    """
+    Destruction (lowering) operator.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of Hilbert space.
+    """
+    return np.matrix(np.diag(np.sqrt(range(1, dim)), 1))
+
+def create(dim):
+    """
+    Creation (raising) operator.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of Hilbert space.
+    """
+    return destroy(dim).getH()
+
+def identity(dim):
+    """
+    Identity operator
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of Hilbert space.
+
+    """
+    return np.matrix(np.identity(dim))

--- a/tncontract/one_dimension.py
+++ b/tncontract/one_dimension.py
@@ -326,7 +326,7 @@ class MatrixProductState(OneDimensionalTensorNetwork):
                             str(first_site_not_right_canonised))
         return (first_site_not_left_canonised, first_site_not_right_canonised)
 
-    def svd_compress(self, chi, threshold=10**-15, normalise=False):
+    def svd_compress(self, chi=0, threshold=10**-15, normalise=False):
         """Simply right canonise the left canonical form according to 
         Schollwock"""
         self.left_canonise(threshold=threshold, normalise=normalise)
@@ -335,6 +335,10 @@ class MatrixProductState(OneDimensionalTensorNetwork):
     def physdim(self, site):
         """Return physical index dimesion for site"""
         return self.data[site].index_dimension(self.phys_label)
+
+    def norm(self):
+        """Return norm of mps"""
+        return np.sqrt(inner_product_mps(self, self))
 
     def apply_gate(self, gate, firstsite, gate_outputs=None, gate_inputs=None,
             chi=0, threshold=1e-15):
@@ -956,7 +960,10 @@ def onebody_sum_mpo(terms, output_label=None):
         right_label='right', physin_label='physin', physout_label='physout')
 
 
-def expvals_mps(mps, oplist, output_label=None, canonised=None):
+def expvals_mps(mps, oplist, output_label=None, canonised=None,
+        normalise=False):
+    # TODO: Figure out why this gives strange results when canonised keyword
+    # is used.
     """
     Return single site expectation values <op>_i for all i
 
@@ -972,6 +979,9 @@ def expvals_mps(mps, oplist, output_label=None, canonised=None):
         to be the output index.
     canonised : {'left', 'right', None}, optional
         Flag to specify theat `mps` is already in left or right canonical form.
+    normalise : bool, optional
+        If True and `canonised=None` the state will be normalised before
+        computing expectation values.
 
     Returns
     ------
@@ -993,7 +1003,7 @@ def expvals_mps(mps, oplist, output_label=None, canonised=None):
         mps.reverse()
         oplist_new = oplist_new[::-1]
     elif canonised != 'right':
-        mps.right_canonise()
+        mps.right_canonise(normalise=normalise)
 
     for k, op in enumerate(oplist_new):
         # compute exp value for site k

--- a/tncontract/onedim/__init__.py
+++ b/tncontract/onedim/__init__.py
@@ -5,4 +5,4 @@ onedimensional
 Subpackage for one dimensional tensor networks
 """
 from tncontract.onedim.onedim_core import *
-import tncontract.onedim.onedim_utils
+from tncontract.onedim.onedim_utils import *

--- a/tncontract/onedim/onedim_utils.py
+++ b/tncontract/onedim/onedim_utils.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 from tncontract import tensor as tnc
-from tncontract import onedim as onedim
+# from tncontract import onedim as onedim
 
 
 def init_mps_random(nsites, physdim, bonddim=1, left_label='left',
@@ -43,7 +43,7 @@ def init_mps_random(nsites, physdim, bonddim=1, left_label='left',
     bonddim = [1] + bonddim + [1]
     tensors = [tnc.Tensor(np.random.rand(physdim[i], bonddim[i], bonddim[i+1]),
         [phys_label, left_label, right_label]) for i in range(nsites)]
-    return onedim.MatrixProductState(tensors, left_label=left_label,
+    return tnc.onedim.MatrixProductState(tensors, left_label=left_label,
             right_label=right_label, phys_label=phys_label)
 
 
@@ -71,7 +71,7 @@ def init_mps_allzero(nsites, physdim, left_label='left',
             right_label])
         tensors.append(t)
 
-    return onedim.MatrixProductState(tensors, left_label=left_label,
+    return tnc.onedim.MatrixProductState(tensors, left_label=left_label,
         right_label=right_label, phys_label=phys_label)
 
 
@@ -102,7 +102,7 @@ def init_mps_logical(nsites, basis_state, physdim, left_label='left',
             right_label])
         tensors.append(t)
 
-    return onedim.MatrixProductState(tensors, left_label=left_label,
+    return tnc.onedim.MatrixProductState(tensors, left_label=left_label,
         right_label=right_label, phys_label=phys_label)
 
 
@@ -156,7 +156,7 @@ def onebody_sum_mpo(terms, output_label=None):
                     B[k,l,:,:] = [[k==l, 0], [term[k, l], k==l]]
             tensors.append(tnc.Tensor(B, ['physout', 'physin', 
                 'left', 'right']))
-    return onedim.MatrixProductOperator(tensors, left_label='left',
+    return tnc.onedim.MatrixProductOperator(tensors, left_label='left',
         right_label='right', physin_label='physin', physout_label='physout')
 
 

--- a/tncontract/onedim/onedim_utils.py
+++ b/tncontract/onedim/onedim_utils.py
@@ -5,14 +5,15 @@ onedim_utils
 Module with various functions for MPS/MPOs.
 """
 
-__all__ = ['init_mps_random', 'onebody_sum_mpo', 'expvals_mps']
+__all__ = ['init_mps_random', 'init_mps_allzero', 'init_mps_logical',
+        'onebody_sum_mpo', 'expvals_mps']
 
 
 import numpy as np
 
 
-from tncontract import tensor as tsr
-from tncontract import onedim as od
+from tncontract import tensor as tnc
+from tncontract import onedim as onedim
 
 
 def init_mps_random(nsites, physdim, bonddim=1, left_label='left',
@@ -40,10 +41,70 @@ def init_mps_random(nsites, physdim, bonddim=1, left_label='left',
     if not np.iterable(bonddim):
         bonddim = [bonddim]*(nsites-1)
     bonddim = [1] + bonddim + [1]
-    tensors = [tsr.Tensor(np.random.rand(physdim[i], bonddim[i], bonddim[i+1]),
+    tensors = [tnc.Tensor(np.random.rand(physdim[i], bonddim[i], bonddim[i+1]),
         [phys_label, left_label, right_label]) for i in range(nsites)]
-    return od.MatrixProductState(tensors, left_label=left_label,
+    return onedim.MatrixProductState(tensors, left_label=left_label,
             right_label=right_label, phys_label=phys_label)
+
+
+def init_mps_allzero(nsites, physdim, left_label='left',
+        right_label='right', phys_label='phys'):
+    """
+    Create an MPS with `nsites` sites in the "all zero" state |00..0>.
+
+    Parameters
+    ----------
+    nsites : int
+    physdim : int or list of ints
+    left_label : str
+    right_label : str
+    phys_label : str
+    """
+    if not np.iterable(physdim):
+        physdim = [physdim]*nsites
+
+    tensors = []
+    for j in range(nsites):
+        t = np.zeros(physdim[j])
+        t[0] = 1.0
+        t = tnc.Tensor(t.reshape(physdim[j], 1, 1), [phys_label, left_label,
+            right_label])
+        tensors.append(t)
+
+    return onedim.MatrixProductState(tensors, left_label=left_label,
+        right_label=right_label, phys_label=phys_label)
+
+
+def init_mps_logical(nsites, basis_state, physdim, left_label='left',
+        right_label='right', phys_label='phys'):
+    """
+    Create an MPS with `nsites` sites in the logical basis state |ijk..l>.
+
+    Parameters
+    ----------
+    nsites : int
+    basis_state : int or list of ints
+        Site `i` will be in the state |`basis_state[i]`> (or simply
+        |`basis_state`> if a single int is provided).
+    physdim : int or list of ints
+    left_label : str
+    right_label : str
+    phys_label : str
+    """
+    if not np.iterable(physdim):
+        physdim = [physdim]*nsites
+
+    tensors = []
+    for j in range(nsites):
+        t = np.zeros(physdim[j])
+        t[basis_state[j]] = 1.0
+        t = tnc.Tensor(t.reshape(physdim[j], 1, 1), [phys_label, left_label,
+            right_label])
+        tensors.append(t)
+
+    return onedim.MatrixProductState(tensors, left_label=left_label,
+        right_label=right_label, phys_label=phys_label)
+
 
 
 def onebody_sum_mpo(terms, output_label=None):
@@ -81,21 +142,21 @@ def onebody_sum_mpo(terms, output_label=None):
             for k in range(term.shape[0]):
                 for l in range(term.shape[1]):
                     B[k,l,:] = [term[k, l], k==l]
-            tensors.append(tsr.Tensor(B, ['physout', 'physin', 'right']))
+            tensors.append(tnc.Tensor(B, ['physout', 'physin', 'right']))
         elif i==len(terms)-1:
             B = np.zeros(shape=term.shape+[2], dtype=complex)
             for k in range(term.shape[0]):
                 for l in range(term.shape[1]):
                     B[k,l,:] = [k==l, term[k, l]]
-            tensors.append(tsr.Tensor(B, ['physout', 'physin', 'left']))
+            tensors.append(tnc.Tensor(B, ['physout', 'physin', 'left']))
         else:
             B = np.zeros(shape=term.shape+[2,2], dtype=complex)
             for k in range(term.shape[0]):
                 for l in range(term.shape[1]):
                     B[k,l,:,:] = [[k==l, 0], [term[k, l], k==l]]
-            tensors.append(tsr.Tensor(B, ['physout', 'physin', 
+            tensors.append(tnc.Tensor(B, ['physout', 'physin', 
                 'left', 'right']))
-    return od.MatrixProductOperator(tensors, left_label='left',
+    return onedim.MatrixProductOperator(tensors, left_label='left',
         right_label='right', physin_label='physin', physout_label='physout')
 
 
@@ -150,8 +211,8 @@ def expvals_mps(mps, oplist, output_label=None, canonised=None):
             in_label = [x for x in op.labels if x is not out_label][0]
         Ad = A.copy()
         Ad.conjugate()
-        exp = tsr.contract(A, op, mps.phys_label, in_label)
-        exp = tsr.contract(Ad, exp, mps.phys_label, out_label)
+        exp = tnc.contract(A, op, mps.phys_label, in_label)
+        exp = tnc.contract(Ad, exp, mps.phys_label, out_label)
         exp.contract_internal(mps.left_label, mps.left_label, index1=0,
                 index2=1)
         exp.contract_internal(mps.right_label, mps.right_label, index1=0,

--- a/tncontract/onedim/onedim_utils.py
+++ b/tncontract/onedim/onedim_utils.py
@@ -5,6 +5,9 @@ onedim_utils
 Module with various functions for MPS/MPOs.
 """
 
+__all__ = ['init_mps_random', 'onebody_sum_mpo', 'expvals_mps']
+
+
 import numpy as np
 
 
@@ -97,6 +100,7 @@ def onebody_sum_mpo(terms, output_label=None):
 
 
 def expvals_mps(mps, oplist, output_label=None, canonised=None):
+    # TODO: Why canonised gives strange results?
     """
     Return single site expectation values <op>_i for all i
 

--- a/tncontract/onedim/onedim_utils.py
+++ b/tncontract/onedim/onedim_utils.py
@@ -13,6 +13,7 @@ import numpy as np
 
 
 from tncontract import tensor as tnc
+from tncontract.onedim import onedim_core as onedim
 # from tncontract import onedim as onedim
 
 
@@ -43,7 +44,7 @@ def init_mps_random(nsites, physdim, bonddim=1, left_label='left',
     bonddim = [1] + bonddim + [1]
     tensors = [tnc.Tensor(np.random.rand(physdim[i], bonddim[i], bonddim[i+1]),
         [phys_label, left_label, right_label]) for i in range(nsites)]
-    return tnc.onedim.MatrixProductState(tensors, left_label=left_label,
+    return onedim.MatrixProductState(tensors, left_label=left_label,
             right_label=right_label, phys_label=phys_label)
 
 
@@ -71,7 +72,7 @@ def init_mps_allzero(nsites, physdim, left_label='left',
             right_label])
         tensors.append(t)
 
-    return tnc.onedim.MatrixProductState(tensors, left_label=left_label,
+    return onedim.MatrixProductState(tensors, left_label=left_label,
         right_label=right_label, phys_label=phys_label)
 
 
@@ -102,7 +103,7 @@ def init_mps_logical(nsites, basis_state, physdim, left_label='left',
             right_label])
         tensors.append(t)
 
-    return tnc.onedim.MatrixProductState(tensors, left_label=left_label,
+    return onedim.MatrixProductState(tensors, left_label=left_label,
         right_label=right_label, phys_label=phys_label)
 
 
@@ -156,7 +157,7 @@ def onebody_sum_mpo(terms, output_label=None):
                     B[k,l,:,:] = [[k==l, 0], [term[k, l], k==l]]
             tensors.append(tnc.Tensor(B, ['physout', 'physin', 
                 'left', 'right']))
-    return tnc.onedim.MatrixProductOperator(tensors, left_label='left',
+    return onedim.MatrixProductOperator(tensors, left_label='left',
         right_label='right', physin_label='physin', physout_label='physout')
 
 

--- a/tncontract/qutip_conv.py
+++ b/tncontract/qutip_conv.py
@@ -11,6 +11,7 @@ import numpy as np
 import qutip as qt
 
 import tncontract as tn
+import tncontract.onedim as onedim
 
 
 def qobj_to_tensor(qobj, labels=None, trim_dummy=True):
@@ -132,7 +133,6 @@ def qobjlist_to_mpo(qobjlist):
             # wrong dims (not a ket, bra or operator)
             raise ValueError("qobj element not a ket/bra/operator")
 
-        nsys = len(qobj.dims[0])
         t = qobj_to_tensor(qobj, trim_dummy=False)
 
         # Add left and right indices with bonddim one
@@ -140,10 +140,10 @@ def qobjlist_to_mpo(qobjlist):
         t.add_dummy_index('right', -1)
 
         # Break up many-body operators by SVDing
-        tmp_mpo = tn.tensor_to_mpo(t)
+        tmp_mpo = onedim.tensor_to_mpo(t)
 
         tensors = np.concatenate((tensors, tmp_mpo.data))
-    return tn.MatrixProductOperator(tensors, left_label='left',
+    return onedim.MatrixProductOperator(tensors, left_label='left',
         right_label='right', physin_label='physin', physout_label='physout')
 
 
@@ -162,5 +162,5 @@ def qobjlist_to_mps(qobjlist):
         t.remove_all_dummy_indices(labels=[mpo.physin_label])
         # Change physical label to the standard choice 'phys'
         t.replace_label(mpo.physout_label, 'phys')
-    return tn.MatrixProductState(tensors, left_label='left',
+    return onedim.MatrixProductState(tensors, left_label='left',
         right_label='right', phys_label='phys')

--- a/tncontract/qutip_conv.py
+++ b/tncontract/qutip_conv.py
@@ -1,4 +1,7 @@
 """
+qutip_conv
+==========
+
 QuTiP / tncontract conversions.
 
 Functionality for converting between `qutip.Qobj` and `Tensor`.
@@ -48,7 +51,7 @@ def qobj_to_tensor(qobj, labels=None, trim_dummy=True):
     else:
         output_labels = labels[:nsys]
         input_labels = labels[nsys:]
-    t = tn.matrix_to_tensor(data, output_dims, input_dims, output_labels,
+    t = tn.matrix_to_tensor(data, output_dims+input_dims, output_labels+
             input_labels)
     if trim_dummy:
         t.remove_all_dummy_indices()

--- a/tncontract/tensor.py
+++ b/tncontract/tensor.py
@@ -1,12 +1,12 @@
 import warnings
 import numpy as np
 import scipy as sp
-import uuid
 
 __all__ = ['Tensor', 'contract', 'distance', 'matrix_to_tensor',
         'tensor_to_matrix', 'random_tensor', 'tensor_product', 'tensor_svd',
-        'truncated_svd', 'unique_label', 'zeros_tensor', 'prime_label',
-        'unprime_label', 'prime_level']
+        'truncated_svd', 'zeros_tensor']
+
+from tncontract import label as lbl
 
 class Tensor():
     """
@@ -114,7 +114,7 @@ class Tensor():
         for i, label in enumerate(self.labels):
             for noprime_label in labels:
                 if noprime_label(label) == noprime_label:
-                    self.labels[i] = prime_label(self.labels[i])
+                    self.labels[i] = lbl.prime_label(self.labels[i])
 
     def unprime_label(self, labels):
         """
@@ -141,7 +141,7 @@ class Tensor():
         for i, label in enumerate(self.labels):
             for noprime_label in labels:
                 if noprime_label(label) == noprime_label:
-                    self.labels[i] = unprime_label(self.labels[i])
+                    self.labels[i] = lbl.unprime_label(self.labels[i])
 
     def contract_internal(self, label1, label2, index1=0, index2=0):
         """By default will contract the first index with label1 with the 
@@ -278,75 +278,6 @@ class Tensor():
     def shape(self):
         return self.data.shape
 
-
-class PrimedLabel(str):
-    """Wrapper class for priming string-like labels"""
-
-    def __new__(cls, value, parent=None):
-        return str.__new__(cls, value)
-
-    def __init__(self, label, parent=None):
-        self._parent = parent
-
-    @property
-    def parent(self):
-        """Return parent label"""
-        return self._parent
-
-    @property
-    def origin(self):
-        """Return origin label"""
-        origin = self
-        while hasattr(origin, "parent"):
-            origin = origin.parent
-        return origin
-
-    @property
-    def parents(self):
-        """Return number of parents for label"""
-        tmp = self
-        level = 0
-        while hasattr(tmp, "parent"):
-            if tmp.parent is not None:
-                tmp = tmp.parent
-                level += 1
-            else:
-                break
-        return level
-
-def prime_label(label, prime="'"):
-    """Put a prime on a label object"""
-    return PrimedLabel(label+prime, parent=label)
-
-def unprime_label(label, prime="'"):
-    """Remove one prime from label object"""
-    try:
-        parent = label.parent
-    except AttributeError:
-        raise ValueError("label is not primed")
-    if parent+prime == label:
-        return parent
-    else:
-        raise ValueError("label is not primed with \"" + prime + "\"")
-
-def noprime_label(label):
-    """Remove all primes from a label object"""
-    try:
-        return label.origin
-    except AttributeError:
-        return label
-
-def prime_level(label):
-    """Return number of primes on label object"""
-    try:
-        return label.parents
-    except AttributeError:
-        return 0
-
-
-def unique_label():
-    """Generate a long, random string that is very likely to be unique."""
-    return str(uuid.uuid4())
 
 #Tensor constructors
 def random_tensor(*args, labels=[], base_label="i"):

--- a/tncontract/tensor.py
+++ b/tncontract/tensor.py
@@ -287,20 +287,19 @@ class PrimedLabel(str):
 
     def __init__(self, label, parent=None):
         self._parent = parent
-        try:
-            self._origin = parent.origin
-        except AttributeError:
-            self._origin = parent
-
-    @property
-    def origin(self):
-        """Return origin label"""
-        return self._origin
 
     @property
     def parent(self):
         """Return parent label"""
         return self._parent
+
+    @property
+    def origin(self):
+        """Return origin label"""
+        origin = self
+        while hasattr(origin, "parent"):
+            origin = origin.parent
+        return origin
 
     @property
     def parents(self):
@@ -319,12 +318,16 @@ def prime_label(label, prime="'"):
     """Put a prime on a label object"""
     return PrimedLabel(label+prime, parent=label)
 
-def unprime_label(label):
+def unprime_label(label, prime="'"):
     """Remove one prime from label object"""
     try:
-        return label.parent
+        parent = label.parent
     except AttributeError:
-        return label
+        raise ValueError("label is not primed")
+    if parent+prime == label:
+        return parent
+    else:
+        raise ValueError("label is not primed with \"" + prime + "\"")
 
 def noprime_label(label):
     """Remove all primes from a label object"""

--- a/tncontract/tensor.py
+++ b/tncontract/tensor.py
@@ -115,23 +115,15 @@ class Tensor():
         >>> t.prime_label('idx')
         >>> print(t)
         Tensor object: shape = (2,), labels = ['idx_p']
-        Tensor data =
-        [1 0]
         >>> t.prime_label('idx')
         >>> print(t)
         Tensor object: shape = (2,), labels = ['idx_p_p']
-        Tensor data =
-        [1 0]
         >>> t.unprime_label('idx')
         >>> print(t)
         Tensor object: shape = (2,), labels = ['idx_p']
-        Tensor data =
-        [1 0]
         >>> t.unprime_label('idx')
         >>> print(t)
         Tensor object: shape = (2,), labels = ['idx']
-        Tensor data =
-        [1 0]
         """
         if not isinstance(labels, list):
             labels=[labels]

--- a/tncontract/tensor.py
+++ b/tncontract/tensor.py
@@ -400,7 +400,7 @@ def matrix_to_tensor(matrix, output_dims, input_dims, output_labels,
     return Tensor(np.reshape(matrix, tuple(output_dims)+tuple(input_dims)), 
             output_labels+input_labels)
 
-def tensor_svd(tensor, row_labels, svd_label="svd"):
+def tensor_svd(tensor, row_labels, svd_label="svd_"):
     """
     Compute the singular value decomposition of `tensor` after reshaping it 
     into a matrix.

--- a/tncontract/tensor.py
+++ b/tncontract/tensor.py
@@ -142,8 +142,8 @@ class Tensor():
         if not isinstance(labels, list):
             labels=[labels]
         for i, label in enumerate(self.labels):
-            for noprime_label in labels:
-                if noprime_label(label) == noprime_label:
+            for noprime in labels:
+                if lbl.noprime_label(label) == noprime:
                     self.labels[i] = lbl.prime_label(self.labels[i])
 
     def unprime_label(self, labels):
@@ -169,8 +169,8 @@ class Tensor():
         if not isinstance(labels, list):
             labels=[labels]
         for i, label in enumerate(self.labels):
-            for noprime_label in labels:
-                if noprime_label(label) == noprime_label:
+            for noprime in labels:
+                if lbl.noprime_label(label) == noprime:
                     self.labels[i] = lbl.unprime_label(self.labels[i])
 
     def contract_internal(self, label1, label2, index1=0, index2=0):


### PR DESCRIPTION
- New module `label` for things related to labels. The main new feature is that you can put a prime (') on arbitrary label objects with the functions `prime_label` and `unprime_label`. This is done behind the scenes by creating a new `Label` object (I thought about calling this `PrimedLabel`, but the class is very generic so I called it `Label` in case it would be used for other purposes in the future). If a `Label` object is created by `prime_label`, it remembers the original "unprimed" label object. At the moment the `Label` class is not imported and only used indirectly by the `prime_label` etc. functions. Note that `unique_label` has been moved to the new `label` module!

Example

``` python
>>> l = tnc.prime_label(np.sin) # l will be a `Label` object, which is a subclass of `str`
>>> print(l) # Note the prime
<ufunc 'sin'>'
>>> l = tnc.unprime_label(l)
>>> l is np.sin # we get back the original object
True
>>> t = tnc.Tensor(np.array([1,0]), labels=[np.sin])
>>> print(t)
Tensor object: shape = (2,), labels = [<ufunc 'sin'>]
>>> t.prime_label(sin)
>>> print(t)
Tensor object: shape = (2,), labels = ["<ufunc 'sin'>'"]
>>> t.unprime_label(sin)
>>> print(t)
Tensor object: shape = (2,), labels = [<ufunc 'sin'>]
```
- A module `matrices` for common matrices such as Pauli matrices and "destruction/creation" operators for a qudit.
- `Tensor*object` multiplication: If a `Tensor` is multiplied with an object, it attempts to create a copy of the `Tensor` with `Tensor.data` replaced by `Tensor.data*object`. The main use of this is to make it easy to multiply with a scalar. I considered throwing an exception if `object` is not scalar, but at the moment it can basically be multiplied with anything that can be multiplied with its `data` attribute. This means that things like a `Tensor*Tensor` multiplication actually works but might not give a very intuitive result. Let me know what you think about this.. I'm happy to change it to only allow multiplication with a scalar (which I think is intuitive enough?).
- Two new functions for easy initialization of MPS: `init_mps_allzero` and `init_mps_logical` in `onedim_utils`.
